### PR TITLE
fix bug where hebrew date increments at midnight

### DIFF
--- a/hebcal/util/proccess_time.py
+++ b/hebcal/util/proccess_time.py
@@ -5,17 +5,17 @@ import datetime
 
 def proccess_datetime(raw_datetime, **kwargs):
     """Proccess a datetime string or object
-    
+
     Convert a datetime string into a datetime object and adds UTC timzone
     offset to the datetime
-    
+
     Arguments:
-        raw_datetime {str/datetime.datetime} -- datetime string in 
+        raw_datetime {str/datetime.datetime} -- datetime string in
         {YYYY-MM-DD HH-MM-SS} format.
-        
+
         **kwargs {key word arguments} -- Valid keyword arguments are:
               timezone {str} -- valid pytz timezone (i.e. America/New_York)
-    
+
     Returns:
         datetime.datetime object -- datetime object including localization info
     """
@@ -24,7 +24,7 @@ def proccess_datetime(raw_datetime, **kwargs):
         proccessed_datetime = raw_datetime
     else:
         proccessed_datetime = parse_datetime_str(raw_datetime)
-    
+
     if 'timezone' in kwargs:
         proccessed_datetime = add_timezone_to_datetime(proccessed_datetime,
                                                        kwargs['timezone'])
@@ -33,13 +33,13 @@ def proccess_datetime(raw_datetime, **kwargs):
 
 def parse_datetime_str(raw_datetime):
     """Parse a datetime string
-    
+
     use dateutil.parser.parse to parse a datetime string
-    
+
     Arguments:
         raw_datetime {str} -- datetime string in {YYYY-MM-DD HH-MM-SS} format.
                               other formats may also work.
-    
+
     Returns:
         object -- datetime.datetime object
     """
@@ -47,7 +47,13 @@ def parse_datetime_str(raw_datetime):
 
 
 def add_timezone_to_datetime(datetime, timezone):
-    return datetime.astimezone(pytz.timezone(timezone))
+    # If there is no tzinfo set, datetime assumes machine localtime.
+    # pytz localize fixes this when timezone differs from localtime.
+    if datetime.tzinfo is None:
+        tz = pytz.timezone(timezone)
+        return tz.localize(datetime, is_dst=None)
+    else:
+        return datetime.astimezone(pytz.timezone(timezone))
 
 
 def convert_datetime_to_utc(datetime):

--- a/tests/test_TimeInfo.py
+++ b/tests/test_TimeInfo.py
@@ -1,3 +1,4 @@
+import datetime
 import hebcal
 
 ti = hebcal.TimeInfo('2018, 9, 19, 7:15 pm', timezone='America/New_York',
@@ -38,3 +39,20 @@ def test_is_next_hebrew_day():
 def test_today_dawn():
     assert str(ti.today_dawn()) == '2018-09-19 05:20:28.556570-04:00'
 
+
+# Verify that the hebrew date does not increase at midnight.
+def test_midnight():
+    heb_dates = [ti.hebrew_date()]
+
+    # Get a week of times incrementing by an hour.
+    n_days = 7
+    hour_delta = 1
+
+    for i in range(n_days * 24 // hour_delta):
+        ti.date_time += datetime.timedelta(hours=hour_delta)
+        heb_dates.append(ti.hebrew_date())
+
+    # Monotonically increasing the gregorian date should mean that the
+    # hebrew dates list should be pre-sorted.
+    for hd, sd in zip(heb_dates, sorted(heb_dates)):
+        assert hd == sd

--- a/tests/test_parshios.py
+++ b/tests/test_parshios.py
@@ -1,10 +1,11 @@
 import hebcal
+from hebcal import parshios
 
 
 ti = hebcal.TimeInfo('2018, 9, 19, 7:15 pm', timezone='America/New_York',
                      latitude=40.092383, longitude=-74.219996)
 
-parshios = hebcal.Parshios(ti)
+parshios = parshios.Parshios(ti)
 
 
 def test_parsha_string():


### PR DESCRIPTION
**Problem**

* The Hebrew date increments at midnight when it shouldn't.
* The unittests fail outside of eastern time.

**Solution**

* Added an `is_pm` check to line 129 of time_into.py to ensure the hebrew date doesn't increment after midnight.
* Added a timezone fix to `add_timezone_to_datetime` for when the specified timezone isn't the local timezone.

**Tests**

* Added `test_midnight` to `tests/test_TimeInfo.py` to verify the bugfix.